### PR TITLE
Fix jet tokenizer and add code usage plots

### DIFF
--- a/models/vqvaeMLP_jet.py
+++ b/models/vqvaeMLP_jet.py
@@ -59,9 +59,13 @@ class VQVAEJet(nn.Module):
         commitment_cost=0.25,
         mean=None,
         std=None,
+        vq_kwargs=None,
     ):
         super().__init__()
         assert mean is not None and std is not None, "Must provide global mean and std as [1, 4] tensors"
+
+        if vq_kwargs is None:
+            vq_kwargs = {}
 
         self.norm = FeatureNormJet(mean, std)
         self.encoder = EncoderJet(input_dim, hidden_dim, z_dim)
@@ -73,6 +77,7 @@ class VQVAEJet(nn.Module):
             affine_lr=0.1,
             affine_groups=1,
             replace_freq=10,
+            **vq_kwargs,
         )
         self.decoder = DecoderJet(z_dim, hidden_dim, input_dim)
 

--- a/models/vqvaeMLP_particle.py
+++ b/models/vqvaeMLP_particle.py
@@ -63,9 +63,13 @@ class VQVAE(nn.Module):
         commitment_cost=0.25,
         mean=None,
         std=None,
+        vq_kwargs=None,
     ):
         super().__init__()
         assert mean is not None and std is not None, "Must provide global mean and std as [1, 1, 4] tensors"
+
+        if vq_kwargs is None:
+            vq_kwargs = {}
 
         self.norm = FeatureNorm(mean, std)
         self.encoder = Encoder(input_dim, hidden_dim, z_dim)
@@ -77,6 +81,7 @@ class VQVAE(nn.Module):
             affine_lr=0.1,             # optional affine codebook transform
             affine_groups=1,           # keep as 1 unless you want grouped affine
             replace_freq=10,            # optionally replace dead codes every N steps
+            **vq_kwargs,
         )
         self.decoder = Decoder(z_dim, hidden_dim, input_dim)
 

--- a/plot/plot.py
+++ b/plot/plot.py
@@ -278,6 +278,20 @@ def plot_difference(orig_jets: torch.Tensor, recon_jets: torch.Tensor,
     print(f"✅ Saved plot to {filename}")
 
 
+def plot_code_histogram(indices: torch.Tensor, num_codes: int, filename: str) -> None:
+    """Plot a histogram of code usage."""
+    indices = indices.view(-1).cpu().numpy()
+    plt.figure(figsize=(6, 4))
+    bins = np.arange(num_codes + 1) - 0.5
+    plt.hist(indices, bins=bins, edgecolor="black")
+    plt.xlabel("Code index")
+    plt.ylabel("Count")
+    plt.title("Codebook Usage")
+    plt.tight_layout()
+    plt.savefig(filename, dpi=300)
+    print(f"✅ Saved plot to {filename}")
+
+
 if __name__ == "__main__":
     plot_all()
 

--- a/scripts/train_all.py
+++ b/scripts/train_all.py
@@ -244,6 +244,7 @@ def ddp_train(rank: int, world_size: int, config: dict) -> None:
         epoch_loss = torch.zeros(1, device=device)
         recon_loss = torch.zeros(1, device=device)
         vq_loss = torch.zeros(1, device=device)
+        codes_this_epoch = []
         
         batch_count = 0
         for batch_idx, batch in enumerate(dataloader):
@@ -277,6 +278,8 @@ def ddp_train(rank: int, world_size: int, config: dict) -> None:
             epoch_loss += loss.detach()
             recon_loss += r_loss.detach()
             vq_loss += v_loss.detach()
+            if "q" in loss_dict:
+                codes_this_epoch.append(loss_dict["q"].detach().cpu())
 
             # Log batch metrics every 50 batches (more frequent)
             if rank == 0 and batch_idx % 50 == 0:
@@ -298,6 +301,9 @@ def ddp_train(rank: int, world_size: int, config: dict) -> None:
         for t in (epoch_loss, recon_loss, vq_loss):
             dist.all_reduce(t, op=dist.ReduceOp.SUM)
             t /= world_size
+        if codes_this_epoch:
+            codes_tensor = torch.cat(codes_this_epoch).to(device)
+            dist.all_reduce(codes_tensor, op=dist.ReduceOp.SUM)
 
         if rank == 0:
             print(
@@ -316,6 +322,14 @@ def ddp_train(rank: int, world_size: int, config: dict) -> None:
                 "unique_codes": unique_codes,
                 "learning_rate": optimizer.param_groups[0]['lr']
             })
+
+            if epoch + 1 == config["num_epochs"] and codes_this_epoch:
+                codes_tensor = torch.cat(codes_this_epoch)
+                plot_code_histogram(
+                    codes_tensor,
+                    config["vq_kwargs"]["num_codes"],
+                    os.path.join(PLOT_DIR, f"all_code_hist_epoch_{epoch+1}.png"),
+                )
             
             # Save checkpoint every 5 epochs or at the end
             if (epoch + 1) % 5 == 0 or epoch + 1 == config["num_epochs"]:

--- a/scripts/train_jet.py
+++ b/scripts/train_jet.py
@@ -6,7 +6,11 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.cuda.amp import GradScaler, autocast
 import models.vqvaeMLP_jet as vqvae
-from plot.plot import plot_tensor_jet_features, reconstruct_jet_features_from_particles
+from plot.plot import (
+    plot_tensor_jet_features,
+    reconstruct_jet_features_from_particles,
+    plot_code_histogram,
+)
 from dataloader.dataloader import load_jetclass_label_as_tensor
 import vector
 
@@ -22,6 +26,15 @@ start = 10
 end = 11
 checkpoint_dir = "checkpoints/checkpoints_jet"
 os.makedirs(checkpoint_dir, exist_ok=True)
+
+vq_kwargs = {
+    "num_codes": 1024,
+    "beta": 0.25,
+    "affine_lr": 0.0,
+    "sync_nu": 2,
+    "replace_freq": 20,
+    "dim": -1,
+}
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 print("\U0001F4E6 Loading full dataset for global normalization...")
@@ -40,10 +53,11 @@ model = vqvae.VQVAEJet(
     input_dim=3,
     hidden_dim=256,
     z_dim=128,
-    num_embeddings=1024,
-    commitment_cost=0.25,
+    num_embeddings=vq_kwargs["num_codes"],
+    commitment_cost=vq_kwargs["beta"],
     mean=global_mean,  # [1, 1, 4]
-    std=global_std     # [1, 1, 4]
+    std=global_std,    # [1, 1, 4]
+    vq_kwargs=vq_kwargs,
 )
 model = model.to(device)
 optimizer = optim.Adam(model.parameters(), lr=lr, betas=(0.9, 0.95))
@@ -66,6 +80,7 @@ for epoch in range(start_epoch, start_epoch + num_epochs):
     epoch_loss = []
     total_recon_loss = []
     total_vq_loss = []
+    codes_this_epoch = []
 
     for _, x_jet, _ in dataloader:
         x_jets = x_jet.to(device)       # (B,  4)
@@ -84,6 +99,8 @@ for epoch in range(start_epoch, start_epoch + num_epochs):
         epoch_loss.append(loss.detach())
         total_recon_loss.append(recon_loss.detach())
         total_vq_loss.append(vq_loss.detach())
+        if isinstance(loss_dict, dict) and "q" in loss_dict:
+            codes_this_epoch.append(loss_dict["q"].detach().cpu())
 
     if epoch % 10 == 0:
         print(f"\U0001F4C8 Epoch [{epoch+1}/{num_epochs}] - Total: {torch.stack(epoch_loss).mean().item():.4f} | Recon: {torch.stack(total_recon_loss).mean().item():.4f} | VQ: {torch.stack(total_vq_loss).mean().item():.4f}")
@@ -98,6 +115,13 @@ for epoch in range(start_epoch, start_epoch + num_epochs):
             "optimizer_state": optimizer.state_dict(),
         }, save_path)
         print(f"\U0001F4BE Saved checkpoint: {save_path}")
+        if codes_this_epoch:
+            codes_tensor = torch.cat(codes_this_epoch).view(-1)
+            plot_code_histogram(
+                codes_tensor,
+                vq_kwargs["num_codes"],
+                os.path.join(PLOT_DIR, f"jet_code_hist_epoch_{epoch+1}.png"),
+            )
 
 # === Post-Training Recon Analysis ===
 model.eval()


### PR DESCRIPTION
## Summary
- add `vq_kwargs` support to jet and particle tokenizers
- plot code usage histograms
- integrate histogram plotting into `train_all.py` and `train_jet.py`

## Testing
- `python -m py_compile models/vqvaeMLP_jet.py models/vqvaeMLP_particle.py scripts/train_jet.py scripts/train_all.py plot/plot.py`

------
https://chatgpt.com/codex/tasks/task_e_68622f46b86c8325b3f383f10db0fbff